### PR TITLE
Fix TLS issues with powershell invocation

### DIFF
--- a/fake.cmd
+++ b/fake.cmd
@@ -1,6 +1,6 @@
 
 REM Install .NET Core (https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script)
-@powershell -NoProfile -ExecutionPolicy unrestricted -Command "&([scriptblock]::Create((Invoke-WebRequest -useb 'https://dot.net/v1/dotnet-install.ps1'))) -Channel Current"
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -useb 'https://dot.net/v1/dotnet-install.ps1')))-Channel Current"
 
 SET PATH=%LOCALAPPDATA%\Microsoft\dotnet;%PATH%
 dotnet restore dotnet-fake.csproj


### PR DESCRIPTION
This changes `fake.cmd` to use TLS1.2 in the powershell script.

This matches the suggested oneliner from microsoft: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script

Without this, dotnet cannot install as the web request fails with a 401 due to the Default TLS being broken.

